### PR TITLE
use DOM elements instead of animated box shadows on group buys

### DIFF
--- a/src/components/group-buy/card.js
+++ b/src/components/group-buy/card.js
@@ -1,0 +1,74 @@
+import React, { forwardRef } from 'react'
+import PropTypes from 'prop-types'
+import { css } from '@emotion/core'
+import styled from '@emotion/styled'
+import { motion } from 'framer-motion'
+
+const Content = styled.div`
+  position: absolute;
+  width: inherit;
+  height: inherit;
+  transition: 0.1s ease-in-out;
+  border-width: 3px;
+  border-style: solid;
+  border-color: ${props => props.theme.colors.text};
+  background: ${props => props.theme.colors.background};
+`
+
+const Container = styled(motion.div)`
+  width: 300px;
+  height: 320px;
+  margin: 0 auto;
+  overflow: hidden;
+  z-index: ${props => (props.active ? '2' : '0')};
+  box-sizing: border-box;
+
+  &:hover {
+    z-index: 2;
+  }
+
+  & > ${Content} {
+    transform: ${props => (props.active ? 'translate(-8px, -8px)' : 'none')};
+  }
+
+  &:hover > ${Content} {
+    transform: translate(-8px, -8px);
+  }
+`
+
+const Shadow = styled.div`
+  position: absolute;
+  width: inherit;
+  height: inherit;
+  background: ${props => props.color || 'gainsboro'};
+`
+
+const variants = {
+  hidden: {
+    opacity: 0
+  },
+  visible: {
+    opacity: 1
+  }
+}
+
+const Card = forwardRef((props, ref) => {
+  return (
+    <Container
+      active={props.active}
+      ref={ref}
+      positionTransition
+      variants={variants}>
+      <Shadow color={props.color} />
+      <Content>{props.children}</Content>
+    </Container>
+  )
+})
+
+Card.propTypes = {
+  color: PropTypes.string,
+  children: PropTypes.node,
+  active: PropTypes.bool
+}
+
+export default Card

--- a/src/components/group-buy/index.js
+++ b/src/components/group-buy/index.js
@@ -11,8 +11,9 @@ import Img from 'gatsby-image'
 import { OutboundLink } from 'gatsby-plugin-google-analytics'
 import { Link as LinkIcon, X as XIcon, List as ListIcon } from 'react-feather'
 
-import Shade from './shade'
-import useSafeArea from '../hooks/use-safe-area'
+import Card from './card'
+import Shade from '../shade'
+import useSafeArea from '../../hooks/use-safe-area'
 
 const wiggle = keyframes`
   25% {
@@ -38,16 +39,10 @@ const zoom = keyframes`
   }
 `
 
-const Card = styled(motion.div)`
-  width: 300px;
-  height: 320px;
-  border: 3px solid #333;
-  margin: 0 auto;
+const Grid = styled.div`
   display: grid;
-  background: #fff;
   grid-template-columns: 1fr;
   grid-template-rows: 174px 140px;
-  transition: 0.1s ease-in-out;
 
   & > .img {
     width: 100%;
@@ -66,18 +61,6 @@ const Card = styled(motion.div)`
       animation-direction: normal;
       animation-fill-mode: forwards;
     }
-  }
-
-  &:hover {
-    box-shadow: 8px 8px 0 ${props => props.accent};
-    transform: translate(-8px, -8px);
-    z-index: 2;
-  }
-
-  &.active {
-    box-shadow: 8px 8px 0 ${props => props.accent};
-    transform: translate(-8px, -8px);
-    z-index: 2;
   }
 `
 
@@ -175,11 +158,7 @@ const linkListVariants = {
       staggerChildren: 0.05
     }
   },
-  hidden: {
-    transition: {
-      staggerChildren: 0.05
-    }
-  }
+  hidden: {}
 }
 
 const Links = ({ placement, width, links }) => {
@@ -254,21 +233,12 @@ Links.propTypes = {
 
 const linksWidth = 256
 
-const animVariants = {
-  hidden: {
-    opacity: 0
-  },
-  visible: {
-    opacity: 1
-  }
-}
-
 const GroupBuy = props => {
   const isMobile = useMedia('screen and (max-width: 676px)', false)
   const [showLinks, setShowLinks] = useState(false)
   const [linksPosition, setLinksPosition] = useState({ x: 0, y: 0 })
   const [showModal, setShowModal] = useState(false)
-  const [cardRef, calculateArea, dimensions] = useSafeArea()
+  const [cardRef, calculateArea] = useSafeArea()
 
   const [info] = useHover(isHovering => (
     <Info
@@ -328,26 +298,24 @@ const GroupBuy = props => {
   return (
     <>
       <Card
-        positionTransition
-        variants={animVariants}
-        transition={{ ease: 'easeInOut', duration: 0.1 }}
         ref={cardRef}
-        accent={props.coverImage.colors.vibrant.light}
-        className={showLinks ? 'active' : ''}
-        style={{ zIndex: showLinks ? 2 : undefined }}>
-        <div className="img" onClick={() => setShowModal(true)}>
-          <Img fixed={props.coverImage.file.childImageSharp.fixed} />
-        </div>
-        {info}
-        <AnimatePresence>
-          {showLinks && (
-            <Links
-              links={props.links}
-              width={linksWidth}
-              placement={isMobile ? 'bottom' : calculateArea()}
-            />
-          )}
-        </AnimatePresence>
+        color={props.coverImage.colors.vibrant.light}
+        active={showLinks}>
+        <Grid>
+          <div className="img" onClick={() => setShowModal(true)}>
+            <Img fixed={props.coverImage.file.childImageSharp.fixed} />
+          </div>
+          {info}
+          <AnimatePresence>
+            {showLinks && (
+              <Links
+                links={props.links}
+                width={linksWidth}
+                placement={isMobile ? 'bottom' : calculateArea()}
+              />
+            )}
+          </AnimatePresence>
+        </Grid>
       </Card>
       <AnimatePresence>
         {showLinks && <Shade onClick={() => setShowLinks(false)} />}

--- a/src/components/shade.js
+++ b/src/components/shade.js
@@ -15,7 +15,6 @@ const ShadeBase = styled(motion.div)`
   z-index: 1;
   opacity: ${props => props.opacity};
   background: ${props => props.background};
-  transition: 0.1s ease-in-out;
   backdrop-filter: blur(5px);
 `
 


### PR DESCRIPTION
Animated box shadows trigger multiple re-renders, creating performance issues. Considering the number of box shadows on this site, it was starting to become noticeably laggy when you moused over a number of cards quickly. This PR fixes this issue by creating a colored `div` that sits behind a group buy, and then the card content is translated on hover as usual. This creates the illusion of a shadow, without actually touching the `box-shadow` property.